### PR TITLE
travis: build both static and shared yaml-cpp libraries.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,11 @@ install:
     - wget -O yaml-cpp-0.5.3.tar.gz https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.5.3.tar.gz
     - tar zxf yaml-cpp-0.5.3.tar.gz --strip 1
     - mkdir build; cd build
+    # - First, build the static library
+    - cmake .. -DPYTHON_EXECUTABLE:FILEPATH=/usr/local/bin/python3
+    - make --quiet
+    - sudo make install 1>/dev/null 2>&1
+    # - Now build the shared library
     - cmake .. -DBUILD_SHARED_LIBS=ON -DPYTHON_EXECUTABLE:FILEPATH=/usr/local/bin/python3
     - make --quiet
     - sudo make install 1>/dev/null 2>&1


### PR DESCRIPTION
Unfortunately, we need to build twice in order to get both libs,
one with and one without setting "DBUILD_SHARED_LIBS=ON"