### PR TITLE
Prepare for buildroot-2019.08

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,8 @@
+    config.mak: change default arches to buildroot-2019.08
+
+    cpsw_api_builder.h: Remove enum keyword when using a typedef-ed enum.
+    This was failing with gcc-8.3.0 on builroot-2019.08
+
     cpsw_preproc: use main yaml directory if yaml_dir is ""
 
     cpsw_yaml rework: provide more context in error messages;
@@ -21,13 +26,13 @@ R4.3.1:
 R4.3.0:
 
     Support for a YAML_PATH env-var. This can list multiple
-    directories where to look for YAML files. Useful, e.g., 
+    directories where to look for YAML files. Useful, e.g.,
     to locate files provided by user or globally which do not
     reside in FW directory.
 
     Added IEntry::dump() to python wrapper. Print useful info,
     (in particular about networking in case of the root node).
- 
+
 R4.2.0:
 
     Changed default RSSI retransmission/cumulative-ack timeouts
@@ -99,7 +104,7 @@ R4.0.0:
     have been migrated.
 
     This means that boost is no longer necessary (if c++11 is available).
-    A few headers (lockfree) are still used but can be disabled in 
+    A few headers (lockfree) are still used but can be disabled in
     the configuration file (switch to a native but simple implementation
     which may or may not be less performant).
 
@@ -120,7 +125,7 @@ R3.branch:
 
     BUGFIX: stack overrun in udpsrv
 
-    Feature: cpsw_mem_dev: support 'offset' property when mapping a 
+    Feature: cpsw_mem_dev: support 'offset' property when mapping a
         file descriptor.
 
     Bugfix: Ipath::parent() implementation was wrong; caused segfault.
@@ -209,7 +214,7 @@ R3.branch:
         The RPC service takes care of remapping UDP to TCP
         ports in case multiple bridges are running (connecting
         to different targets).
- 
+
     Feature: NetIODev supports 'socksProxy' property (SOCKS_PROXY env-
         var is also supported) for selecting a proxy.
 
@@ -242,7 +247,7 @@ R3.branch:
     CFreeList now supports allocate_shared() (single allocation
     from free-list)
 
-    Convert IntFields with bitSize > 64 to be converted to 
+    Convert IntFields with bitSize > 64 to be converted to
     (hex) strings without truncating them (when read as CString).
 
     Fixed MTU calculation for RSSI and DEPACK
@@ -336,7 +341,7 @@ R3.7.branch
     Python: Stream.read() has an optional 'offset' argument
     (same as underlying IStream::read())
 
-    MemDev: FIX - read(NULL) means that the user wants to 
+    MemDev: FIX - read(NULL) means that the user wants to
     know if data are available; must return nonzero.
 
     Added support for thread priorities. All internal threads
@@ -344,7 +349,7 @@ R3.7.branch
     a priority (see doc/README.yamlDefinition).
 
     New features: a 'NullDev' which is not backed by anything.
-    Useful for testing/debugging because any YAML hierarchy 
+    Useful for testing/debugging because any YAML hierarchy
     can be loaded w/o need for hardware (or a lot or memory
     as with MemDev that covers a large address space).
 

--- a/config.mak
+++ b/config.mak
@@ -28,13 +28,13 @@ HARCH=rhel6-x86_64
 
 # ARCHES += xxx yyy
 
-ARCHES += buildroot-2016.11.1-x86_64 buildroot-2016.11.1-i686 buildroot-2016.11.1-arm
- 
- 
+ARCHES += buildroot-2019.08-x86_64 buildroot-2019.08-i686 buildroot-2019.08-arm
+
+
 # Next, you need to define prefixes (which may include
 # absolute paths) so that e.g., $(CROSS_xxx)gcc can be
 # used as a C compiler e.g.,
-# 
+#
 # CROSS_xxx = path_to_xxx_tools/xxx-
 # CROSS_yyy = path_to_yyy_tools/yyy-
 #
@@ -86,7 +86,7 @@ $(foreach brarnam,$(BR_ARNAMS),$(eval CROSS_$(brarnam)=$$(BR_CROSS)))
 #
 # Likewise, you must set
 # boostlib_DIR_xxx, boostlib_DIR_default, boostlib_DIR
-# (or any of boost_DIR, boost_DIR_xxx, boost_DIR_default in 
+# (or any of boost_DIR, boost_DIR_xxx, boost_DIR_default in
 # which case a '/lib' suffix is attached) if 'boost' libraries
 # cannot be found automatically by the (cross) tools.
 #
@@ -94,7 +94,7 @@ $(foreach brarnam,$(BR_ARNAMS),$(eval CROSS_$(brarnam)=$$(BR_CROSS)))
 # or relative to $(CPSW_DIR).
 #
 
-# 
+#
 BOOST_VERSION=1.64.0
 BOOST_PATH=$(PACKAGE_TOP)/boost/$(BOOST_VERSION)
 
@@ -105,7 +105,7 @@ boost_DIR_default=$(BOOST_PATH)/$(TARCH)
 # Analogous to the boost-specific variables a set of
 # variables prefixed by 'yaml_cpp_' is used to identify
 # the install location of yaml-cpp headers and library.
-# 
+#
 YAML_CPP_VERSION         = yaml-cpp-0.5.3_boost-1.64.0
 YAML_CPP_PATH            = $(PACKAGE_TOP)/yaml-cpp/$(YAML_CPP_VERSION)
 

--- a/src/cpsw_api_builder.h
+++ b/src/cpsw_api_builder.h
@@ -399,9 +399,9 @@ class IIntField: public virtual IField {
 public:
 	// Introduce IIntField::Mode for BWDs compatibiliy
     typedef IVal_Base::Mode Mode;
-	static const enum IVal_Base::Mode RW = IVal_Base::RW;
-	static const enum IVal_Base::Mode RO = IVal_Base::RO;
-	static const enum IVal_Base::Mode WO = IVal_Base::WO;
+	static const IVal_Base::Mode RW = IVal_Base::RW;
+	static const IVal_Base::Mode RO = IVal_Base::RO;
+	static const IVal_Base::Mode WO = IVal_Base::WO;
 
 	static const uint64_t DFLT_SIZE_BITS = 32;
 	static const bool     DFLT_IS_SIGNED = false;


### PR DESCRIPTION
Need to remove a `enum` keyword when using a typdef-ed enum, as it was failing to build with the new gcc 8.3.0. 