### PR TITLE
Update config.mak to build against our conda python 3.8 environment

### DIFF
--- a/config.mak
+++ b/config.mak
@@ -134,8 +134,8 @@ FOUND_BOOST_PY=$(if $(boostlib_DIR),$(if $(wildcard $(boostlib_DIR)/libboost_pyt
 
 #py_DIR_default=/afs/slac/g/lcls/package/python/python2.7.9/$(TARCH)
 #pyinc_DIR_default=$(addsuffix /include/python2.7/,$(py_DIR))
-py_DIR_default=/afs/slac/g/lcls/package/python/3.6.1/$(TARCH)
-pyinc_DIR_default=$(addsuffix /include/python3.6m/,$(py_DIR))
+py_DIR_default=/afs/slac/g/lcls/package/anaconda/envs/python3.8envs/v2.5/
+pyinc_DIR_default=$(addsuffix /include/python3.8/,$(py_DIR))
 
 # Whether to use C++11 or boost (note that boost is still used internally
 # by CPSW but enabling C++11 will remove dependency of *applications* on


### PR DESCRIPTION
The current 3.6.1 python environment it's pointing to hasn't been built with rhel 7 support. 

This also has the added benefit of not needing to specify an architecture between rhel6 and 7 since our python 3.8 environment supports both fine by default. I've tied it to v2.5 instead of the soft link just so nothing changes.

Resolves the libicui18n.so issue raised in a cater.