### PR TITLE
src/defs.mak: Improve host system autodetection

### DIFF
--- a/config.mak
+++ b/config.mak
@@ -21,7 +21,7 @@ PACKAGE_TOP=/afs/slac/g/lcls/package
 # you can redefine the name of the host architecture:
 # HARCH = www
 #HARCH=linux-x86_64
-HARCH=rhel6-x86_64
+#HARCH=rhel6-x86_64
 
 # Assuming you also want 'xxx' and 'yyy' then you'd
 # add these to the 'ARCHES' variable:

--- a/src/arch-detect.mak
+++ b/src/arch-detect.mak
@@ -1,0 +1,20 @@
+# //@C Copyright Notice
+# //@C ================
+# //@C This file is part of CPSW. It is subject to the license terms in the LICENSE.txt
+# //@C file found in the top-level directory of this distribution and at
+# //@C https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# //@C
+# //@C No part of CPSW, including this file, may be copied, modified, propagated, or
+# //@C distributed except according to the terms contained in the LICENSE.txt file.
+
+#=================================================#
+# Simple utility script to detect host arch
+#=================================================#
+
+HOST_ARCH:=$(shell uname -r | grep -Eo "el[0-9][0-9]?")
+ifneq ($(HOST_ARCH),)
+	HOST_ARCH:=rhel$(subst el,,$(HOST_ARCH))-$(shell uname -m)
+else
+	HOST_ARCH:=linux-$(shell uname -m)
+endif
+

--- a/src/defs.mak
+++ b/src/defs.mak
@@ -10,8 +10,10 @@
 # (Default) Definitions for CPSW Makefiles
 
 # host architecture
-HARCH_DEFAULT:=linux-$(shell uname -m)
+include $(CPSW_DIR)/arch-detect.mak
+HARCH_DEFAULT:=$(HOST_ARCH)
 HARCH=$(HARCH_DEFAULT)
+
 # Architectures to build
 ARCHES=$(HARCH)
 


### PR DESCRIPTION
Allows RHEL version to be detected and HARCH_DEFAULT set accordingly
This removes the need for setting HARCH explicitly on the command line or in config.mak

