### PR TITLE
defs.mak, config.mak: fix glibc 2.26+ build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,5 @@ README.html
 README.configData.html
 README.yamlDefinition.md
 README.yamlDefinition.html
-rhel6-x86_64/
-rhel7-x86_64/
+rhel*-x86_64/
 buildroot-*/

--- a/config.mak
+++ b/config.mak
@@ -148,6 +148,14 @@ USE_CXX11_default=NO
 # This variable can be set for individual target architectures...
 WITH_BOOST_default=YES
 
+# glibc 2.26+ no longer has an RPC library built in, so RPC support must come from libtirpc instead.
+# You may override this setting in your config.local.mak if this conditional doesn't cover all cases where this is needed.
+ifeq ($(HARCH),$(filter $(HARCH),rhel9-x86_64 rhel8-x86_64))
+USE_TIRPC=YES
+else
+USE_TIRPC=NO
+endif
+
 # Define an install location
 INSTALL_DIR=$(TOPDIR)
 
@@ -161,3 +169,4 @@ POSTPROCESS_ENV_SCRIPT_default=true
 
 GIT_RELEASE_TAG := "$(shell git describe --abbrev=4 --dirty --always --tags)"
 USR_CPPFLAGS += -DGIT_RELEASE_TAG=\"$(GIT_RELEASE_TAG)\"
+

--- a/src/defs.mak
+++ b/src/defs.mak
@@ -211,3 +211,11 @@ else
 -include $(TOPDIR)/config.mak
 -include $(TOPDIR)/config.local.mak
 endif
+
+# Configure tirpc includes and linker flags
+ifeq ($(USE_TIRPC),YES)
+CPPFLAGS+=-I/usr/include/tirpc
+CPSW_LIBS+=tirpc
+CPSW_STATIC_LIBS+=tirpc
+LDFLAGS+=-ltirpc
+endif


### PR DESCRIPTION
glibc 2.26 removed RPC support, so a different library like tirpc must be used instead. Older systems are unaffected by this change, the flag should only be enabled on systems that are using glibc 2.26 or newer.

Split from other PR so it can be fast tracked.