### PR TITLE
Use gawk instead of awk

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -209,7 +209,7 @@ $(addsuffix /,$(SRCDIR))pyyaml_cpp.cc: yaml_cpp.pyx yaml_cpp.pxd
 	$(call maybe_run_cython,$(CYTHON) --cplus $(addprefix -I,$(yaml_cppinc_DIR)) -X language_level=3 -X embedsignature=True $< -o $@)
 
 doc/README.yamlDefinition.md:doc/README.yamlDefinition.in
-	awk 'BEGIN{ FS="[ \t\"]+" } /\<YAML_KEY_/{ printf("s/%s/%s/g\n", $$2, $$3); }' cpsw_yaml_keydefs.h | sed -f - $< > $@
+	gawk 'BEGIN{ FS="[ \t\"]+" } /\<YAML_KEY_/{ printf("s/%s/%s/g\n", $$2, $$3); }' cpsw_yaml_keydefs.h | sed -f - $< > $@
 	if grep 'YAML_KEY_' $@; then \
 		echo 'ERROR: Some YAML_KEY_ tags not expanded (ill-spelled?)' ; \
 		$(RM) $@ ; \


### PR DESCRIPTION
awk may or may not be gawk (GNU awk), depending on if gawk is installed. If awk is *not* gawk, the build fails with cryptic errors related to the autogenerated YAML documentation. By using gawk explicitly, if gawk is not installed, we get a much more clear `Unknown command: gawk` error instead.