### PR TITLE
Build Fixes + Config Improvements

### DIFF
--- a/config.mak
+++ b/config.mak
@@ -15,7 +15,25 @@
 # arbitrarily but should not characters besides
 # [0-9][a-z][A-Z][.][-][_]
 
-PACKAGE_TOP=/afs/slac/g/lcls/package
+# Set defaults for PACKAGE_TOP. In S3DF, this should be the same as EPICS_PACKAGE_TOP
+# This may be overridden in config.local.mak
+ifeq ($(PACKAGE_TOP),)
+ifeq ($(EPICS_PACKAGE_TOP),)
+	PACKAGE_TOP=/afs/slac/g/lcls/package
+else
+	PACKAGE_TOP:=$(EPICS_PACKAGE_TOP)
+endif
+endif
+
+# Set a directory for the toolchain location. in S3DF, this is the same as EPICS_PACKAGE_TOP
+# This may be overridden in config.local.mak
+ifeq ($(TOOLCHAINS),)
+ifeq ($(EPICS_PACKAGE_TOP),)
+	TOOLCHAINS:=/afs/slac/package
+else
+	TOOLCHAINS:=$(EPICS_PACKAGE_TOP)
+endif
+endif
 
 # By default the 'host' architecture is built. But
 # you can redefine the name of the host architecture:
@@ -49,7 +67,7 @@ BR_VERSN=$(word 2,$(subst -, ,$(TARCH)))
 BR_TARCH=$(subst zynq,arm,$(word 3,$(subst -, ,$(TARCH))))
 
 # cross compiler path
-BR_CROSS=/afs/slac/package/linuxRT/buildroot-$(BR_VERSN)/host/$(BR_HARCH)/$(BR_TARCH)/usr/bin/$(BR_TARCH)-linux-
+BR_CROSS=$(TOOLCHAINS)/linuxRT/buildroot-$(BR_VERSN)/host/$(BR_HARCH)/$(BR_TARCH)/usr/bin/$(BR_TARCH)-linux-
 
 # map target arch-name into a make variable name
 BR_ARNAMS=$(subst .,_,$(subst -,_,$(filter buildroot-%,$(ARCHES))))
@@ -134,7 +152,7 @@ FOUND_BOOST_PY=$(if $(boostlib_DIR),$(if $(wildcard $(boostlib_DIR)/libboost_pyt
 
 #py_DIR_default=/afs/slac/g/lcls/package/python/python2.7.9/$(TARCH)
 #pyinc_DIR_default=$(addsuffix /include/python2.7/,$(py_DIR))
-py_DIR_default=/afs/slac/g/lcls/package/anaconda/envs/python3.8envs/v2.4/$(TARCH)
+py_DIR_default=$(PACKAGE_TOP)/anaconda/envs/python3.8envs/v2.4/$(TARCH)
 pyinc_DIR_default=$(addsuffix /include/python3.8/,$(py_DIR))
 
 # Whether to use C++11 or boost (note that boost is still used internally

--- a/config.mak
+++ b/config.mak
@@ -168,10 +168,12 @@ WITH_BOOST_default=YES
 
 # glibc 2.26+ no longer has an RPC library built in, so RPC support must come from libtirpc instead.
 # You may override this setting in your config.local.mak if this conditional doesn't cover all cases where this is needed.
-ifeq ($(HARCH),$(filter $(HARCH),rhel9-x86_64 rhel8-x86_64))
+ifdef TARCH
+ifeq ($(TARCH),$(filter $(TARCH),rhel9-x86_64 rhel8-x86_64))
 USE_TIRPC=YES
 else
 USE_TIRPC=NO
+endif
 endif
 
 # Define an install location

--- a/config.mak
+++ b/config.mak
@@ -18,9 +18,7 @@
 # Set defaults for PACKAGE_TOP. In S3DF, this should be the same as EPICS_PACKAGE_TOP
 # This may be overridden in config.local.mak
 ifeq ($(PACKAGE_TOP),)
-ifeq ($(EPICS_PACKAGE_TOP),)
-	PACKAGE_TOP=/afs/slac/g/lcls/package
-else
+ifneq ($(EPICS_PACKAGE_TOP),)
 	PACKAGE_TOP:=$(EPICS_PACKAGE_TOP)
 endif
 endif

--- a/src/cpsw_python.h
+++ b/src/cpsw_python.h
@@ -158,19 +158,6 @@ public:
 	{
 	}
 
-#if __cplusplus >= 201103L
-	PyUniqueObj(PyUniqueObj &&orig)
-	: up_( cpsw::move( orig.up_ ) )
-	{
-	}
-
-	PyUniqueObj & operator=(PyUniqueObj &&rhs)
-	{
-		up_ = cpsw::move( rhs.up_ );
-		return *this;
-	}
-#endif
-
 	PyUniqueObj & operator=(PyUniqueObj &rhs)
 	{
 		up_ = cpsw::move( rhs.up_ );

--- a/src/defs.mak
+++ b/src/defs.mak
@@ -219,3 +219,8 @@ CPSW_LIBS+=tirpc
 CPSW_STATIC_LIBS+=tirpc
 LDFLAGS+=-ltirpc
 endif
+
+# Check that we have PACKAGE_TOP, otherwise things will fail to build.
+ifeq ($(PACKAGE_TOP),)
+	$(error PACKAGE_TOP or EPICS_PACKAGE_TOP must be provided by your environment, on the command line, or by config.local.mak)
+endif

--- a/src/defs.mak
+++ b/src/defs.mak
@@ -135,7 +135,7 @@ STATIC_LIBRARIES=$(STATIC_LIBRARIES_$(WITH_STATIC_LIBRARIES))
 SHARED_LIBRARIES=$(SHARED_LIBRARIES_$(WITH_SHARED_LIBRARIES))
 
 # Default values -- DO NOT OVERRIDE HERE but in config.mak or config.local.mak
-BOOST_PYTHON_LIB_default     =boost_python
+BOOST_PYTHON_LIB_default     =boost_python3
 WITH_SHARED_LIBRARIES_default=YES
 WITH_STATIC_LIBRARIES_default=NO
 WITH_PYCPSW_default          =$(or $(and $(pyinc_DIR),$(WITH_SHARED_LIBRARIES),CYTHON),NO)

--- a/src/defs.mak
+++ b/src/defs.mak
@@ -138,7 +138,7 @@ SHARED_LIBRARIES=$(SHARED_LIBRARIES_$(WITH_SHARED_LIBRARIES))
 BOOST_PYTHON_LIB_default     =boost_python3
 WITH_SHARED_LIBRARIES_default=YES
 WITH_STATIC_LIBRARIES_default=NO
-WITH_PYCPSW_default          =$(or $(and $(pyinc_DIR),$(WITH_SHARED_LIBRARIES),CYTHON),NO)
+WITH_PYCPSW_default          =$(or $(and $(and $(pyinc_DIR),$(wildcard $(pyinc_DIR)/*),$(pyinc_DIR)),$(WITH_SHARED_LIBRARIES),CYTHON),NO)
 WITH_BOOST_default           =YES
 
 COMMA__:=,

--- a/src/yaml_cpp_python.cc
+++ b/src/yaml_cpp_python.cc
@@ -121,6 +121,6 @@ BOOST_PYTHON_MODULE(yaml_cpp)
 	.value("Map",       YAML::NodeType::Map)
 	;
 
-	def("LoadFile",   &YAML::LoadFile)
+	def("LoadFile",   &YAML::LoadFile);
 	def("emitNode", emitNode);
 }


### PR DESCRIPTION
* Reverted the previous fix applied by #8, it causes build errors with boost python. It seems the build error only occurs on python 3.10+, so I can't reproduce this in S3DF yet either (our current conda env is v2.4 for python 3.8). Going to just revert it for now and address the issue later at some point.
* Link against libboost_python3 instead of libboost_python
* Fix missing semicolon in yaml_cpp_python.cc. I don't know how this ever compiled.....
* Improved portability of config.mak by replacing absolute AFS paths with variables instead.
* Added check for `pyinc_DIR` instead of assuming it exists. This allows us to avoid building python for unsupported targets (i.e. if buildroot-2019.08-arm is not supported by the specified conda env)
* Ensure `TARCH` is defined when we set `USE_TIRPC`.