### PR TITLE
tirpc improvements

### DIFF
--- a/config.mak
+++ b/config.mak
@@ -164,16 +164,6 @@ USE_CXX11_default=NO
 # This variable can be set for individual target architectures...
 WITH_BOOST_default=YES
 
-# glibc 2.26+ no longer has an RPC library built in, so RPC support must come from libtirpc instead.
-# You may override this setting in your config.local.mak if this conditional doesn't cover all cases where this is needed.
-ifdef TARCH
-ifeq ($(TARCH),$(filter $(TARCH),rhel9-x86_64 rhel8-x86_64))
-USE_TIRPC=YES
-else
-USE_TIRPC=NO
-endif
-endif
-
 # Define an install location
 INSTALL_DIR=$(TOPDIR)
 
@@ -184,6 +174,11 @@ INSTALL_DIR=$(TOPDIR)
 # seen from the host...
 POSTPROCESS_ENV_SCRIPT_default=true
 
+# Define the location of libtirpc. This is required for builds targeting
+# systems that use glibc 2.26+, as that version of glibc removed the built-in
+# RPC library.
+tirpcinc_DIR_default=$(PACKAGE_TOP)/tirpc/1.3.5/$(TARCH)/include/tirpc
+tirpclib_DIR_default=$(PACKAGE_TOP)/tirpc/1.3.5/$(TARCH)/lib
 
 GIT_RELEASE_TAG := "$(shell git describe --abbrev=4 --dirty --always --tags)"
 USR_CPPFLAGS += -DGIT_RELEASE_TAG=\"$(GIT_RELEASE_TAG)\"

--- a/src/doc/INSTALL.md
+++ b/src/doc/INSTALL.md
@@ -251,6 +251,18 @@ You could then say
 
 Dont' forget to substitute `-` with `_` in gnumake variable names.
 
+#### 2.3.1 Dependent `tirpc` Package
+
+On Linux systems with GLIBC 2.26+ (rhel8+, for example), CPSW must be
+linked against the 'tirpc' library. You may need to set `WITH_TIRPC_xxx` as
+needed in your `config.local.mak`.
+
+Much like `boost` and `yaml-cpp`, the following variables may be used to 
+control the `tirpc` library and include locations:
+
+        tirpcinc_DIR=
+        tirpclib_DIR=
+
 ### 2.4 Building Static and Shared Libraries.
 
 The makefile system can build either static or shared libraries or

--- a/src/rssi_bridge/makefile
+++ b/src/rssi_bridge/makefile
@@ -34,7 +34,7 @@ rssi_bridge_SRCS+= mapClnt.c
 rssi_bridge_SRCS+= rpcMapServer.c
 
 rssi_bridge_LIBS_NO = cpswTstAux $(CPSW_LIBS)
-rssi_bridge_LIBS_YES= cpswTstAux cpsw.a pthread rt
+rssi_bridge_LIBS_YES= cpswTstAux $(CPSW_STATIC_LIBS)
 rssi_bridge_LIBS=$(rssi_bridge_LIBS_$(WITH_STATIC_LIBRARIES))
 
 rssi_bqm_SRCS += rssi_bqm.cc
@@ -42,7 +42,7 @@ rssi_bqm_SRCS += rpcMapLookup.c
 rssi_bqm_SRCS += prot_xdr.c
 
 rssi_bqm_LIBS_NO = cpswTstAux $(CPSW_LIBS)
-rssi_bqm_LIBS_YES= cpswTstAux cpsw.a pthread rt
+rssi_bqm_LIBS_YES= cpswTstAux $(CPSW_STATIC_LIBS)
 rssi_bqm_LIBS=$(rssi_bqm_LIBS_$(WITH_STATIC_LIBRARIES))
 
 PROGRAMS = rssi_bridge rssi_bqm


### PR DESCRIPTION
I realized that the previous handling of libtirpc was not adequate. It worked well enough for the shared library version of CPSW, but not so well for the static library.

Instead of treating it as a system level dependency, let's treat it no differently than yaml-cpp or boost...