### PR TITLE
Remove unnecessary PACKAGE_TOP check

### DIFF
--- a/src/defs.mak
+++ b/src/defs.mak
@@ -225,7 +225,3 @@ else
 -include $(TOPDIR)/config.local.mak
 endif
 
-# Check that we have PACKAGE_TOP, otherwise things will fail to build.
-ifeq ($(PACKAGE_TOP),)
-	$(error PACKAGE_TOP or EPICS_PACKAGE_TOP must be provided by your environment, on the command line, or by config.local.mak)
-endif


### PR DESCRIPTION
`PACKAGE_TOP` is used by default to select toolchain locations, but this isn't necessary if the user provides their own toolchains in `config.local.mak`