### PR TITLE
Update license to latest SLAC license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,4 @@
-
-Copyright (c) 2015, The Board of Trustees of the Leland Stanford Junior 
+Copyright (c) 2025, The Board of Trustees of the Leland Stanford Junior 
 University, through SLAC National Accelerator Laboratory (subject to receipt 
 of any required approvals from the U.S. Dept. of Energy). All rights reserved. 
 Redistribution and use in source and binary forms, with or without 
@@ -38,4 +37,3 @@ then you hereby grant the following license: a non-exclusive, royalty-free
 perpetual license to install, use, modify, prepare derivative works, incorporate
 into other computer software, distribute, and sublicense such Enhancements or 
 derivative works thereof, in binary and source code form.
-


### PR DESCRIPTION
Last time I updated copyright year I made a typo; 2015 instead of 2025...

Also renamed without the .txt to match the file in https://github.com/slaclab/license