### PR TITLE
Update README again for compliance with SLAC policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-[![Build Status](https://travis-ci.com/slaclab/cpsw.svg?branch=master)](https://travis-ci.com/slaclab/cpsw)
-
 # CPSW: Common Platform Software
+
+![Build Status](https://github.com/slaclab/cpsw/actions/workflows/build.yml/badge.svg)
+[DOE Code](https://www.osti.gov/doecode/biblio/75559)
+[doi:10.11578/dc.20220707.1](https://doi.org/10.11578/dc.20220707.1)
 
 ## Copyright Notice
 This file is part of CPSW. It is subject to the license terms in the LICENSE.txt
@@ -13,3 +15,14 @@ distributed except according to the terms contained in the LICENSE.txt file.
 ## Documentation
 
 The official CPSW documentation is published [here](https://slaclab.github.io/cpsw).
+
+## Copyright Notice:
+            
+COPYRIGHT © SLAC National Accelerator Laboratory. All rights reserved. 
+This work is supported [in part] by the U.S. Department of Energy, Office of Basic Energy Sciences under contract DE-AC02-76SF00515.
+
+## Usage Restrictions:
+
+Neither the name of the Leland Stanford Junior University, SLAC National Accelerator Laboratory, U.S. Department of Energy 
+nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+


### PR DESCRIPTION
According to the SLAC software policy:
1. Required files
     - LICENSE file (BSD 3-Clause or MIT)
     - README.md with:
        - Basic description
        - Installation instructions
        - SLAC attribution

And:

2. Final steps
     - Update repository
         - Add DOI badge to README
         - Ensure the following copyright notice and usage restrictions text is included in the README